### PR TITLE
fix: resolve GitHub Actions cache warning by ensuring go tools directory exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,23 +63,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-tools-
 
+    - name: Ensure go tools directory exists
+      run: |
+        mkdir -p $HOME/go/bin
+        echo "Go tools directory created: $HOME/go/bin"
+
     - name: Install tools
       run: |
         echo "Installing development tools..."
         
-        # Check if tools are already installed
-        if command -v mockgen >/dev/null 2>&1 && command -v gocov >/dev/null 2>&1 && command -v gocov-xml >/dev/null 2>&1 && command -v wire >/dev/null 2>&1; then
-          echo "Tools already installed, skipping installation"
-        else
-          echo "Installing tools..."
-          # Install tools with specific versions for better caching
-          go install github.com/golang/mock/mockgen@v1.6.0 &
-          go install github.com/axw/gocov/gocov@latest &
-          go install github.com/AlekSi/gocov-xml@latest &
-          go install github.com/google/wire/cmd/wire@v0.6.0 &
-          wait
-          echo "Tools installed successfully"
-        fi
+        # Always install tools to ensure they exist in $HOME/go/bin
+        echo "Installing tools to $HOME/go/bin..."
+        go install github.com/golang/mock/mockgen@v1.6.0
+        go install github.com/axw/gocov/gocov@latest
+        go install github.com/AlekSi/gocov-xml@latest
+        go install github.com/google/wire/cmd/wire@v0.6.0
+        
+        echo "Tools installed successfully"
+        echo "Installed tools:"
+        ls -la $HOME/go/bin/
         
         # Add tools to PATH
         echo "$HOME/go/bin" >> $GITHUB_PATH


### PR DESCRIPTION
## Summary

This PR fixes the GitHub Actions cache warning: 'Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.'

## Problem

The cache step was executing before the tools installation step, causing the  directory to not exist when the cache action tried to save it.

## Solution

1. **Added directory creation step**: Ensures  directory exists before caching
2. **Simplified tool installation**: Always install tools instead of conditional installation
3. **Added debugging information**: Shows installed tools for better troubleshooting

## Changes

- Added  step after cache restore
- Removed conditional tool installation logic
- Changed from parallel to sequential tool installation for better stability
- Added tool listing for debugging purposes

## Testing

This should resolve the cache warning and improve CI reliability.